### PR TITLE
Update 2015-12-04-xml-parsing-in-go.markdown

### DIFF
--- a/source/_posts/2015-12-04-xml-parsing-in-go.markdown
+++ b/source/_posts/2015-12-04-xml-parsing-in-go.markdown
@@ -32,7 +32,7 @@ The simplest node to parse is going to be `<name>`. We'll need an object to unma
 
 ``` go
 type Person struct {
-  Name string `xml:"string"`
+  Name string `xml:"name"`
 }
 ```
 


### PR DESCRIPTION
Fix incorrect xml tag identifier from type to tag name
